### PR TITLE
Refactor PR

### DIFF
--- a/lib/mneme/errors.ex
+++ b/lib/mneme/errors.ex
@@ -26,21 +26,31 @@ end
 
 defmodule Mneme.UnboundVariableError do
   @moduledoc false
-  defexception [:vars, :result, :message]
+  defexception [:vars, :message]
 
   @impl true
   def message(%{message: nil} = exception) do
-    %{vars: vars, result: result} = exception
+    %{vars: vars} = exception
 
     """
-    The amended match obsoleted one or several of already bound variables
-      (#{inspect(vars)}) while adjusting for the result #{inspect(result)}.
+    Updated auto-assertion is missing at least one previously bound variable:
 
-    Please run test(s) again.
+        #{format_vars(vars)}
+
+    Re-run this test to ensure it still passes.
     """
   end
 
   def message(%{message: message}) do
     message
+  end
+
+  defp format_vars(vars) do
+    vars
+    |> Enum.map(fn
+      {name, _context} -> name
+      name -> name
+    end)
+    |> Enum.map_join(", ", &Atom.to_string/1)
   end
 end

--- a/lib/mneme/utils.ex
+++ b/lib/mneme/utils.ex
@@ -20,4 +20,108 @@ defmodule Mneme.Utils do
   defp occurrences(<<char, rest::binary>>, char, acc), do: occurrences(rest, char, acc + 1)
   defp occurrences(<<_, rest::binary>>, char, acc), do: occurrences(rest, char, acc)
   defp occurrences(<<>>, _char, acc), do: acc
+
+  @doc """
+  Macro expands an expression in a pattern match context.
+  """
+  @spec expand_pattern(Macro.t(), Macro.Env.t()) :: Macro.t()
+  def expand_pattern({:when, meta, [left, right]}, caller) do
+    left = do_expand_pattern(left, Macro.Env.to_match(caller))
+    right = do_expand_pattern(right, %{caller | context: :guard})
+    {:when, meta, [left, right]}
+  end
+
+  def expand_pattern(expr, caller) do
+    do_expand_pattern(expr, Macro.Env.to_match(caller))
+  end
+
+  defp do_expand_pattern({:quote, _, [_]} = expr, _caller), do: expr
+  defp do_expand_pattern({:quote, _, [_, _]} = expr, _caller), do: expr
+  defp do_expand_pattern({:__aliases__, _, _} = expr, caller), do: Macro.expand(expr, caller)
+
+  defp do_expand_pattern({:@, _, [{attribute, _, _}]}, caller) do
+    caller.module |> Module.get_attribute(attribute) |> Macro.escape()
+  end
+
+  defp do_expand_pattern({left, meta, right} = expr, caller) do
+    case Macro.expand(expr, caller) do
+      ^expr ->
+        {do_expand_pattern(left, caller), meta, do_expand_pattern(right, caller)}
+
+      {left, meta, right} ->
+        {do_expand_pattern(left, caller), [original: expr] ++ meta,
+         do_expand_pattern(right, caller)}
+
+      other ->
+        other
+    end
+  end
+
+  defp do_expand_pattern({left, right}, caller) do
+    {do_expand_pattern(left, caller), do_expand_pattern(right, caller)}
+  end
+
+  defp do_expand_pattern([_ | _] = list, caller) do
+    Enum.map(list, &do_expand_pattern(&1, caller))
+  end
+
+  defp do_expand_pattern(other, _caller), do: other
+
+  @doc """
+  Collects variables bound in the given pattern.
+  """
+  @spec collect_vars_from_pattern(Macro.t()) :: [var] when var: {atom(), Macro.metadata(), atom()}
+  def collect_vars_from_pattern({:when, _, [left, right]}) do
+    pattern = collect_vars_from_pattern(left)
+
+    vars =
+      for {name, _, context} = var <- collect_vars_from_pattern(right),
+          has_var?(pattern, name, context),
+          do: var
+
+    pattern ++ vars
+  end
+
+  def collect_vars_from_pattern(expr) do
+    expr
+    |> Macro.prewalk([], fn
+      {:"::", _, [left, right]}, acc ->
+        {[left], collect_vars_from_binary(right, acc)}
+
+      {skip, _, [_]}, acc when skip in [:^, :@, :quote] ->
+        {:ok, acc}
+
+      {skip, _, [_, _]}, acc when skip in [:quote] ->
+        {:ok, acc}
+
+      {:_, _, context}, acc when is_atom(context) ->
+        {:ok, acc}
+
+      {name, meta, context}, acc when is_atom(name) and is_atom(context) ->
+        {:ok, [{name, meta, context} | acc]}
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp collect_vars_from_binary(right, original_acc) do
+    right
+    |> Macro.prewalk(original_acc, fn
+      {mode, _, [{name, meta, context}]}, acc
+      when is_atom(mode) and is_atom(name) and is_atom(context) ->
+        if has_var?(original_acc, name, context) do
+          {:ok, [{name, meta, context} | acc]}
+        else
+          {:ok, acc}
+        end
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp has_var?(pattern, name, context), do: Enum.any?(pattern, &match?({^name, _, ^context}, &1))
 end

--- a/test/mneme_test.exs
+++ b/test/mneme_test.exs
@@ -40,7 +40,7 @@ defmodule MnemeTest do
     test "existing correct assertions succeed" do
       assertion = Mneme.Assertion.new(quote(do: auto_assert(1 <- 1)), 1, context(__ENV__))
 
-      assert Mneme.Assertion.run(assertion, __ENV__, false)
+      assert Mneme.Assertion.run!(assertion, __ENV__, false)
     end
 
     test "existing incorrect assertions fail with an ExUnit.AssertionError" do
@@ -48,7 +48,7 @@ defmodule MnemeTest do
 
       assert capture_io(fn ->
                assert_raise ExUnit.AssertionError, fn ->
-                 Mneme.Assertion.run(assertion, __ENV__, false)
+                 Mneme.Assertion.run!(assertion, __ENV__, false)
                end
              end) =~ "Mneme is running in non-interactive mode."
     end
@@ -58,7 +58,7 @@ defmodule MnemeTest do
 
       assert capture_io(fn ->
                assert_raise Mneme.AssertionError, fn ->
-                 Mneme.Assertion.run(assertion, __ENV__, false)
+                 Mneme.Assertion.run!(assertion, __ENV__, false)
                end
              end) =~ "Mneme is running in non-interactive mode."
     end


### PR DESCRIPTION
Hey @am-kantox! I know this is getting a little meta -- a PR for a PR -- but I had some ideas for how this could be done a little differently that I was having trouble writing out, so I thought I'd just give it a shot.

The change in strategy here is to store the vars that need to be bound on the `%Assertion{}` struct, and then use the `eval` binding returned from `Assertion.run!` (renamed from `run`, since it raises on failure) to extract the required vars in the correct order. This is done in the new `Assertion.ensure_vars!/2`.